### PR TITLE
Docu: add link to .json file

### DIFF
--- a/www/content/docs/guides/getting-started.md
+++ b/www/content/docs/guides/getting-started.md
@@ -22,7 +22,7 @@ go install github.com/mrled/hedgerules/hedgerules/cmd/hedgerules@latest
 
 ## 2. Add the _hedge_headers.json template
 
-Copy the `index.hedgeheaders.json` layout from the Hedgerules example site into your Hugo site's `layouts/` directory. This template generates a `_hedge_headers.json` file in your build output that maps URL paths to HTTP response headers.
+Copy the [`index.hedgeheaders.json`](https://raw.githubusercontent.com/mrled/hedgerules/refs/heads/master/examples/micahrlweb/index.cfheader.json) file template from the Hedgerules example site into your Hugo site's `layouts/` directory. This template generates a `_hedge_headers.json` file in your build output that maps URL paths to HTTP response headers.
 
 You also need to register the output format in your `hugo.toml`:
 


### PR DESCRIPTION
This PR adds a link to the template file to the setup guide.

Just realized that teh naming of the template file is inconsistent:

**link name**: `index.hedgeheaders.json`
**file name**: `index.cfheader.json`

This should be harmonized, too. What file name is the desired one?