### PR TITLE
Docu: fix broken link

### DIFF
--- a/www/content/docs/guides/getting-started.md
+++ b/www/content/docs/guides/getting-started.md
@@ -31,7 +31,7 @@ You also need to register the output format in your `hugo.toml`:
   home = ["HTML", "hedgeheaders", "hedgeredirects"]
 ```
 
-The output format definitions are provided by the theme. If you're not using the theme, see the [Configuration Reference](/docs/configuration/) for the full output format config.
+The output format definitions are provided by the theme. If you're not using the theme, see the [Configuration Reference](/docs/themes/configuration/) for the full output format config.
 
 ## 3. Configure headers in hugo.toml
 


### PR DESCRIPTION
This PR fixes a broken link I spotted in the documentation.